### PR TITLE
Fix indexing errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Generated files
+links.txt

--- a/main.py
+++ b/main.py
@@ -85,6 +85,14 @@ def process_link(choice, link):
         print(f">>> ❌ Error processing {link}: {e}")
 
 
+def sort_key(item):
+    try:
+        return int(item[1])
+    except ValueError:
+        # Return a very large number or a string that sorts appropriately
+        return float('inf')  # To put special episodes at the end
+        # Or return a string like "ZZZZ" to put them at the end alphabetically
+
 def fetch_download(choice, links):
     # Fetch downloads using multi-threading.
     with ThreadPoolExecutor(max_workers=5) as executor:  # Use 5 threads
@@ -95,7 +103,7 @@ def fetch_download(choice, links):
     while not dlinks_queue.empty():
         dlinks.append(dlinks_queue.get())
 
-    dlinks.sort(key=lambda li: int(li[1]))
+    dlinks.sort(key=sort_key)
     save_links_to_file(dlinks)  # Save to file after all threads complete
 
 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ HEADERS = ({
 
 def convert_size(size_str):
     # Convert file size from MB/GB format to a float (in MB).
-    size_str = size_str.upper().strip()
+    size_str = size_str.replace(",","").upper().strip()
     if 'GB' in size_str:
         return float(size_str.replace('GB', '').strip()) * 1024  # Convert GB to MB
     elif 'MB' in size_str:

--- a/main.py
+++ b/main.py
@@ -86,12 +86,12 @@ def process_link(choice, link):
 
 
 def sort_key(item):
+    # Custom sort key function for sorting download links.
     try:
         return int(item[1])
     except ValueError:
-        # Return a very large number or a string that sorts appropriately
+        # Return a very large number that sorts appropriately
         return float('inf')  # To put special episodes at the end
-        # Or return a string like "ZZZZ" to put them at the end alphabetically
 
 def fetch_download(choice, links):
     # Fetch downloads using multi-threading.


### PR DESCRIPTION
Addresses #6, and fixes error when file size labels have commas.  Also adds a `.gitignore` file to avoid cluttering git diffs with changes to generated files like `links.txt`. It seems to run fine without the `links.txt` and regenerates it when deleted.